### PR TITLE
Fix code snippet indentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ by adding a step to your workflow.
 ```yaml
   - name: Tailscale
     uses: tailscale/github-action@v1
-      with:
-        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+    with:
+      authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 ```
 
 Subsequent steps in the Action can then access nodes in your Tailnet.


### PR DESCRIPTION
When I copy/pasted the code snippet GitHub Actions complained about an error in my YAML configuration. Seems like the indentation for the `with` key is off by one level.