### PR TITLE
Add optional `args` input to customize tailscale up command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 # Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-name: 'Connect Tailscale'
-description: 'Connect your GitHub Action workflow to Tailscale'
+name: 'Connect Tailscale (args)'
+description: 'Connect your GitHub Action workflow to Tailscale (forked)'
 branding:
   icon: 'arrow-right-circle'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,11 @@ inputs:
   version:
     description: 'Tailscale version to use.'
     required: true
-    default: '1.14.0'
+    default: '1.16.2'
+  args:
+    description: 'Optional additional arguments to `tailscale up`'
+    required: false
+    default: ''
 runs:
     using: 'composite'
     steps:
@@ -41,7 +45,7 @@ runs:
         run: |
           sudo tailscaled 2>~/tailscaled.log &
           HOSTNAME="github-$(cat /etc/hostname)"
-          until sudo tailscale up --authkey ${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes
+          until sudo tailscale up --authkey ${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${INPUTS_ARGS}
           do
             sleep 0.5
           done

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,8 @@ runs:
         shell: bash
         env:
           TAILSCALE_AUTHKEY: ${{ inputs.authkey }}
+          ADDITIONAL_ARGS: ${{ inputs.args }}
         run: |
           sudo tailscaled 2>~/tailscaled.log &
           HOSTNAME="github-$(cat /etc/hostname)"
-          sudo tailscale up --authkey ${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${INPUT_ARGS}
+          sudo tailscale up --authkey ${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${ADDITIONAL_ARGS}

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 # Copyright (c) 2021 Tailscale Inc & AUTHORS All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
-name: 'Connect Tailscale (args)'
-description: 'Connect your GitHub Action workflow to Tailscale (forked)'
+name: 'Connect Tailscale'
+description: 'Connect your GitHub Action workflow to Tailscale'
 branding:
   icon: 'arrow-right-circle'
   color: 'gray-dark'


### PR DESCRIPTION
The current action doesn't allow for any customization of the `tailscale up` command.  The two current use cases we have for this are:
* advertising tags for granular ACLs
* setting --host-routes=false (the large number of config change propagations from the ephemeral machines was putting undue strain on network)

Additional this PR bumps the default version to 1.16.2