### PR TITLE
Update to 1.18, remove loop

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: 'Tailscale version to use.'
     required: true
-    default: '1.14.0'
+    default: '1.18.0'
 runs:
     using: 'composite'
     steps:
@@ -41,7 +41,4 @@ runs:
         run: |
           sudo tailscaled 2>~/tailscaled.log &
           HOSTNAME="github-$(cat /etc/hostname)"
-          until sudo tailscale up --authkey ${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes
-          do
-            sleep 0.5
-          done
+          sudo tailscale up --authkey ${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes


### PR DESCRIPTION
In release 1.16 and later, "tailscale up" will block until it can
connect to tailscaled and bring the link up. There is not a need
to loop any more.