### PR TITLE
Add ephemeral auth and teardown

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -18,8 +18,15 @@ jobs:
       - name: Tailscale Action
         uses: ./
         with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          apikey: ${{ secrets.TAILSCALE_APIKEY }}
 
-      - name: check for hello.ipn.dev in netmap
+      - name: check for hello.ts.net in netmap
         run:
           tailscale status | grep -q hello
+          
+      - name: Stop Tailscale
+        if: always()
+        uses: ./
+        with:
+          apikey: ${{ secrets.TAILSCALE_APIKEY }}
+          action: down

--- a/README.md
+++ b/README.md
@@ -3,20 +3,41 @@
 This GitHub Action connects to your [Tailscale network](https://tailscale.com)
 by adding a step to your workflow.
 
+↓ Use this action before you need access to your Tailnet in your workflow ↓
 ```yaml
-  - name: Tailscale
-    uses: tailscale/github-action@v1
+  - name: Run Tailscale
+    uses: tailscale/github-action@v2
       with:
-        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+        apikey: ${{ secrets.TAILSCALE_APIKEY }}
+        tailnet: ${{ secrets.TAILSCALE_TAILNET }}
+        # optional, overrides auto ephemeral authkey generation
+        # authkey: ${{ secrets.TAILSCALE_AUTHKEY }} 
 ```
 
 Subsequent steps in the Action can then access nodes in your Tailnet.
 
+↓ Use this action at the end of your workflow to remove the ephemeral node from your Tailnet ↓
+```yaml
+  - name: Remove Tailscale
+    if: always()
+    uses: tailscale/github-action@v2
+      with:
+        action: down
+        apikey: ${{ secrets.TAILSCALE_APIKEY }}
+```
+
+TAILSCALE\_APIKEY is an [apikey](https://github.com/tailscale/tailscale/blob/main/api.md)
+for automatic [ephemeral authkey](https://tailscale.com/kb/1111/ephemeral-nodes/) 
+generation. These tend to be a good fit for GitHub runners, as they clean up their state 
+automatically shortly after the runner finishes.
+
+TAILSCALE\_TAILNET is the name of the [tailnet](https://github.com/tailscale/tailscale/blob/main/api.md#tailnet) 
+the runner will join if using automatic ephemeral auth. By default it is set to the 
+tailnet that corresponds to your GitHub account.
+
 TAILSCALE\_AUTHKEY is an [authkey](https://tailscale.com/kb/1085/auth-keys/) 
 for the Tailnet to be accessed, and needs to be populated in the Secrets for
-your workflow. [Ephemeral authkeys](https://tailscale.com/kb/1111/ephemeral-nodes/) tend
-to be a good fit for GitHub runners, as they clean up their state automatically shortly
-after the runner finishes.
+your workflow if not using automatic ephemeral auth.
 
 ----
 

--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,18 @@ branding:
   icon: 'arrow-right-circle'
   color: 'gray-dark'
 inputs:
+  action:
+    description: 'set to "down" to remove machine from tailnet'
+  apikey:
+    description: 'Your Tailscale API key, from the admin panel'
+  tailnet:
+    description: 'The name of your Tailscale network' 
   authkey:
     description: 'Your Tailscale authentication key, from the admin panel.'
-    required: true
   version:
     description: 'Tailscale version to use.'
     required: true
-    default: '1.18.2'
+    default: '1.22.1'
   args:
     description: 'Optional additional arguments to `tailscale up`'
     required: false
@@ -22,6 +27,7 @@ runs:
     using: 'composite'
     steps:
       - name: Download Tailscale
+        if: inputs.action != 'down'
         shell: bash
         id: download
         env:
@@ -39,11 +45,33 @@ runs:
           TSPATH=/tmp/tailscale_${VERSION}_amd64
           sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
       - name: Run Tailscale
+        if: inputs.action != 'down'
         shell: bash
         env:
+          TAILSCALE_APIKEY: ${{ inputs.apikey }}
+          TAILSCALE_TAILNET: ${{ inputs.tailnet }}
           TAILSCALE_AUTHKEY: ${{ inputs.authkey }}
           ADDITIONAL_ARGS: ${{ inputs.args }}
         run: |
+          sudo hostnamectl set-hostname github-$(cut -d "/" -f2- <<< "$GITHUB_REPOSITORY")-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
+          : "${TAILSCALE_TAILNET:=$GITHUB_ACTOR.github}"
+          : ${TAILSCALE_AUTHKEY:=$( \
+            echo '{"capabilities":{"devices":{"create":{"reusable":false,"ephemeral":true}}}}' | curl \
+              -X POST --data-binary @- https://api.tailscale.com/api/v2/tailnet/$TAILSCALE_TAILNET/keys \
+              -u "$TAILSCALE_APIKEY:" \
+              -H "Content-Type: application/json" | jq -r ".key" \
+          )}
           sudo tailscaled 2>~/tailscaled.log &
-          HOSTNAME="github-$(cat /etc/hostname)"
+          HOSTNAME="$(cat /etc/hostname)"
           sudo tailscale up --authkey ${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${ADDITIONAL_ARGS}
+      - name: Stop Tailscale
+        if: inputs.action == 'down'
+        shell: bash
+        env:
+          TAILSCALE_APIKEY: ${{ inputs.apikey }}
+          TAILSCALE_TAILNET: ${{ inputs.tailnet }}
+        run: |
+          : "${TAILSCALE_TAILNET:=$GITHUB_ACTOR.github}"
+          ID=$(curl "https://api.tailscale.com/api/v2/tailnet/$TAILSCALE_TAILNET/devices" -u "$TAILSCALE_APIKEY:" | jq -r '.devices[] | select (.hostname=='\"$HOSTNAME\"') .id')
+          curl -X DELETE "https://api.tailscale.com/api/v2/device/$ID" \
+            -u "$TAILSCALE_APIKEY:"


### PR DESCRIPTION
Changes:

* Update to 1.22.1
* Change runner in default workflow to check hello.ts.net per https://tailscale.com/kb/1073/hello/
* Add automatic ephemeral authkey generation via apikey
* Add teardown step invoked by:
```yaml
with:
  action: down
```

v2 tag would need to be added for the README blob to work in external workflows.