### PR TITLE
Add capability to pass fixed hostname

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Optional additional arguments to `tailscale up`'
     required: false
     default: ''
+  hostname:
+    description: 'Fixed hostname to use.'
+    required: false
+    default: ''
 runs:
     using: 'composite'
     steps:
@@ -43,7 +47,10 @@ runs:
         env:
           TAILSCALE_AUTHKEY: ${{ inputs.authkey }}
           ADDITIONAL_ARGS: ${{ inputs.args }}
+          HOSTNAME: ${{ inputs.hostname }}
         run: |
           sudo tailscaled 2>~/tailscaled.log &
-          HOSTNAME="github-$(cat /etc/hostname)"
+          if [[ -z "${HOSTNAME}" ]]; then
+            HOSTNAME="github-$(cat /etc/hostname)"
+          fi
           sudo tailscale up --authkey ${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${ADDITIONAL_ARGS}


### PR DESCRIPTION
Hello,
Currently the tailscale agent would assign the hostname based on the real hostname of the machine. Often this is undesirable, and we'd like to have a fixed value of this hostname. Hence, I'm proposing that we have the capability to pass a custom hostname in the input.