### PR TITLE
Bump Tailscale version to use (1.36.0)

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Tailscale Action
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: 'Tailscale version to use.'
     required: true
-    default: '1.32.1'
+    default: '1.36.0'
   args:
     description: 'Optional additional arguments to `tailscale up`'
     required: false


### PR DESCRIPTION
Bumps Tailscale version to use to 1.36.0 from 1.32.1