### PR TITLE
Move 'tailscale up' to its own step.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,14 +54,21 @@ runs:
           rm tailscale.tgz
           TSPATH=/tmp/tailscale_${VERSION}_amd64
           sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
-      - name: Run Tailscale
+      - name: Start Tailscale Daemon
+        shell: bash
+        run: |
+          sudo tailscaled 2>~/tailscaled.log &
+          # And check that tailscaled came up. The CLI will block for a bit waiting
+          # for it. And --json will make it exit with status 0 even if we're logged
+          # out (as we will be). Without --json it returns an error if we're not up.
+          sudo tailscale status --json >/dev/null
+      - name: Connect to Tailscale
         shell: bash
         env:
           TAILSCALE_AUTHKEY: ${{ inputs.authkey }}
           ADDITIONAL_ARGS: ${{ inputs.args }}
           HOSTNAME: ${{ inputs.hostname }}
         run: |
-          sudo tailscaled 2>~/tailscaled.log &
           if [ -z "${HOSTNAME}" ]; then
             HOSTNAME="github-$(cat /etc/hostname)"
           fi


### PR DESCRIPTION
So tailscaled doesn't run with the authkey in its env. It doesn't need to know, so don't provide it. Defense in depth.