### PR TITLE
Add support for OAuth Authentication

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Tailscale Action
         uses: ./

--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -18,9 +18,11 @@ jobs:
       - name: Tailscale Action
         uses: ./
         with:
-          client_id: ${{ secrets.OAUTH_CLIENT_ID }}
-          client_secret: ${{ secrets.OAUTH_CLIENT_SECRET }}
-          device_tag: ${{ secrets.DEVICE_TAG }}
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          ## uncomment below to use OAuth Auth
+          # client_id: ${{ secrets.OAUTH_CLIENT_ID }}
+          # client_secret: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          # device_tag: ${{ secrets.DEVICE_TAG }}
 
       - name: check for hello.ipn.dev in netmap
         run:

--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -18,8 +18,10 @@ jobs:
       - name: Tailscale Action
         uses: ./
         with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          client_id: ${{ secrets.OAUTH_CLIENT_ID }}
+          client_secret: ${{ secrets.OAUTH_CLIENT_SECRET }}
+          device_tag: ${{ secrets.DEVICE_TAG }}
 
       - name: check for hello.ipn.dev in netmap
         run:
-          tailscale status | grep -q hello
+          tailscale status | grep -q ^100

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,14 @@ branding:
   icon: 'arrow-right-circle'
   color: 'gray-dark'
 inputs:
-  authkey:
-    description: 'Your Tailscale authentication key, from the admin panel.'
+  client_id:
+    description: 'Your Tailscale OAuth App client id'
     required: true
+  client_secret:
+    description: 'Your Tailscale OAuth App client secret'
+    required: true
+  device_tag:
+    description: 'Tag to tag the device with (ex. tag:example)'
   version:
     description: 'Tailscale version to use.'
     required: true
@@ -32,10 +37,10 @@ runs:
           echo "::error title=⛔ error hint::Support Linux Only"
           exit 1
       - name: Check Auth Key Empty
-        if: ${{ inputs.authkey == '' }}
+        if: ${{ inputs.client_id == '' || inputs.client_secret == '' }}
         shell: bash
         run: |
-          echo "::error title=⛔ error hint::Auth key empty, Maybe you need to populate it in the Secrets for your workflow, see more in https://docs.github.com/en/actions/security-guides/encrypted-secrets"
+          echo "::error title=⛔ error hint::client_id or client_secret empty, Maybe you need to populate it in the Secrets for your workflow, see more in https://docs.github.com/en/actions/security-guides/encrypted-secrets"
           exit 1
       - name: Download Tailscale
         shell: bash
@@ -54,6 +59,52 @@ runs:
           rm tailscale.tgz
           TSPATH=/tmp/tailscale_${VERSION}_amd64
           sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
+      - name: Generate ephemeral authkey
+        id: authenticate
+        shell: bash
+        env:
+          OAUTH_CLIENT_ID: ${{ inputs.client_id }}
+          OAUTH_CLIENT_SECRET: ${{ inputs.client_secret }}
+          DEVICE_TAG: ${{ inputs.device_tag }}
+        run: |
+           token=$(curl -s \
+               -d "client_id=${OAUTH_CLIENT_ID}" \
+               -d "client_secret=${OAUTH_CLIENT_SECRET}" \
+               "https://api.tailscale.com/api/v2/oauth/token" | jq -r .access_token)
+
+           if [ "x$token" == "x" ]; then
+              echo "::error title=⛔ error hint::Failed to acuqire access token"
+              exit 1
+           fi
+
+           request=$(cat << EOF
+           {
+            "capabilities": {
+              "devices": {
+                "create": {
+                  "reusable": false,
+                  "ephemeral": true,
+                  "preauthorized": true,
+                  "tags": [ "$DEVICE_TAG" ]
+               }
+              }
+            },
+            "expirySeconds": 600
+           }
+           EOF
+           )
+
+           authkey=$(echo "$request" | curl -s "https://api.tailscale.com/api/v2/tailnet/-/keys" \
+               -u "$token:" \
+               --data-binary @- | jq -r .key)
+
+           if [ "x$authkey" == "x" ]; then
+              echo "::error title=⛔ error hint::Failed to acuqire device authkey"
+              exit 1
+           fi
+
+           echo authkey="$authkey" >> $GITHUB_OUTPUT
+
       - name: Start Tailscale Daemon
         shell: bash
         run: |
@@ -65,7 +116,7 @@ runs:
       - name: Connect to Tailscale
         shell: bash
         env:
-          TAILSCALE_AUTHKEY: ${{ inputs.authkey }}
+          TAILSCALE_AUTHKEY: ${{ steps.authenticate.outputs.authkey }}
           ADDITIONAL_ARGS: ${{ inputs.args }}
           HOSTNAME: ${{ inputs.hostname }}
         run: |

--- a/action.yml
+++ b/action.yml
@@ -7,14 +7,18 @@ branding:
   icon: 'arrow-right-circle'
   color: 'gray-dark'
 inputs:
+  authkey:
+    description: 'Your Tailscale authentication key, from the admin panel. Optional if you use OAuth'
+    required: false
   client_id:
-    description: 'Your Tailscale OAuth App client id'
-    required: true
+    description: 'Your Tailscale OAuth App client id. Required for OAuth'
+    required: false
   client_secret:
-    description: 'Your Tailscale OAuth App client secret'
-    required: true
+    description: 'Your Tailscale OAuth App client secret. Required for OAuth'
+    required: false
   device_tag:
-    description: 'Tag to tag the device with (ex. tag:example)'
+    description: 'Tag to tag the device with (ex. tag:example). Required for OAuth'
+    required: false
   version:
     description: 'Tailscale version to use.'
     required: true
@@ -37,10 +41,10 @@ runs:
           echo "::error title=⛔ error hint::Support Linux Only"
           exit 1
       - name: Check Auth Key Empty
-        if: ${{ inputs.client_id == '' || inputs.client_secret == '' }}
+        if: ${{ inputs.authkey == '' && (inputs.client_id == '' || inputs.client_secret == '' || inputs.device_tag == '') }}
         shell: bash
         run: |
-          echo "::error title=⛔ error hint::client_id or client_secret empty, Maybe you need to populate it in the Secrets for your workflow, see more in https://docs.github.com/en/actions/security-guides/encrypted-secrets"
+          echo "::error title=⛔ error hint::authkey, client_id, client_secret or device_tag empty, Maybe you need to populate it in the Secrets for your workflow, see more in https://docs.github.com/en/actions/security-guides/encrypted-secrets"
           exit 1
       - name: Download Tailscale
         shell: bash
@@ -60,6 +64,7 @@ runs:
           TSPATH=/tmp/tailscale_${VERSION}_amd64
           sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
       - name: Generate ephemeral authkey
+        if: ${{ inputs.authkey == '' }}
         id: authenticate
         shell: bash
         env:
@@ -116,7 +121,7 @@ runs:
       - name: Connect to Tailscale
         shell: bash
         env:
-          TAILSCALE_AUTHKEY: ${{ steps.authenticate.outputs.authkey }}
+          TAILSCALE_AUTHKEY: ${{ inputs.authkey || steps.authenticate.outputs.authkey }}
           ADDITIONAL_ARGS: ${{ inputs.args }}
           HOSTNAME: ${{ inputs.hostname }}
         run: |


### PR DESCRIPTION
This PR fixes #59 

When using OAuth authentication, the generated authkey will be tailnet-owned and thus a tag needs to be provided, so providing a tag is mandatory when using OAuth Authentication.

Currently only one tag is supported - I'm not good enough at shell escaping to do multiple tags in a reliable way (😈), but if somebody wants to add more in the future: feel free, of course.

One commit switches to OAuth auth explicitly, and a followup commit re-adds support for authkey, though, TBH, that's not so useful given the limited lifetime of authkeys, but to honor backwards compatibility, why not keep it?