### PR TITLE
add timeout on steps with network I/O

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
           if ! [[ "$SHA256SUM" ]] ; then
             SHA256SUM="$(curl "${URL}.sha256")"
           fi
-          curl "$URL" -o tailscale.tgz
+          curl "$URL" -o tailscale.tgz --max-time 300
           echo "$SHA256SUM  tailscale.tgz" | sha256sum -c
           tar -C /tmp -xzf tailscale.tgz
           rm tailscale.tgz
@@ -113,4 +113,4 @@ runs:
             TAILSCALE_AUTHKEY="${{ inputs['oauth-secret'] }}?preauthorized=true&ephemeral=true"
             TAGS_ARG="--advertise-tags=${{ inputs.tags }}"
           fi
-          sudo -E tailscale up ${TAGS_ARG} --authkey=${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${ADDITIONAL_ARGS}
+          timeout 5m sudo -E tailscale up ${TAGS_ARG} --authkey=${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${ADDITIONAL_ARGS}


### PR DESCRIPTION
Set a reasonable timeout to prevent jobs from hanging for hours (https://github.com/tailscale/github-action/issues/50). 5 minutes is way longer than should ever be necessary, but accounts for intermittent networking issues on either the actions runner or the Tailscale package or control server.  Users can always set a shorter timeout on their own action step.

Fixes #50