### PR TITLE
Split OAuth empty error message to create new absent tags error message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,10 +50,16 @@ runs:
           echo "::error title=⛔ error hint::Support Linux Only"
           exit 1
       - name: Check Auth Info Empty
-        if: ${{ inputs.authkey == '' && (inputs['oauth-secret'] == '' || inputs.tags == '') }}
+        if: ${{ inputs.authkey == '' && inputs['oauth-secret'] == '' }}
         shell: bash
         run: |
           echo "::error title=⛔ error hint::OAuth identity empty, Maybe you need to populate it in the Secrets for your workflow, see more in https://docs.github.com/en/actions/security-guides/encrypted-secrets and https://tailscale.com/s/oauth-clients"
+          exit 1
+      - name: Check Tags Provided
+        if: ${{ inputs.authkey == '' && inputs.tags == '' }}
+        shell: bash
+        run: |
+          echo "::error title=⛔ error hint::At least one ACL tag is required for nodes created by this Action. Ensure an appropriate tag exists in your ACL and provide it in your workflow. See more in https://tailscale.com/kb/1068/acl-tags/"
           exit 1
       - name: Download Tailscale
         shell: bash


### PR DESCRIPTION
Creates a new error condition, evaluated after the check for empty OAuth credentials, that is triggered if neither an `authkey` not a `tags` is provided. IIUC, `tags` is not required if an `authkey` is provided because that `authkey` may be generated with tags, but we don't know that at runtime.

Fixes #78.