### PR TITLE
workflow: allow manual testing

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -1,6 +1,7 @@
 name: tailscale
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
We periodically have reports of failures in the GitHub Action where there has been no recent change in Tailscale infrastructure and no indication of a problem in metrics or monitoring.

Right now we have to generate a pull request to get this test workflow to run. Allow it to be run manually whenever desired.