### PR TITLE
Update Tailscale default version to 1.66.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   version:
     description: 'Tailscale version to use.'
     required: true
-    default: '1.66.3'
+    default: '1.66.4'
   sha256sum:
     description: 'Expected SHA256 checksum of the tarball.'
     required: false


### PR DESCRIPTION
I noticed that the default version was out of date, hence this PR.