### PR TITLE
Update default Tailscale version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   version:
     description: 'Tailscale version to use.'
     required: true
-    default: '1.42.0'
+    default: '1.60.0'
   sha256sum:
     description: 'Expected SHA256 checksum of the tarball.'
     required: false


### PR DESCRIPTION
Hey,

This pull request updates the default Tailscale version in the GitHub Action from 1.42.0 to 1.60.0, addressing a known security vulnerability. Tailscale recommends version 1.60.0 or later for enhanced security.