### PR TITLE
Fail if curl gets a non-200 response code

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -22,6 +22,7 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
+          version: 1.64.0
 
       - name: check for hello.ts.net in netmap
         run:

--- a/README.md
+++ b/README.md
@@ -40,3 +40,6 @@ Which Tailscale version to use can be set like this:
       tags: tag:ci
       version: 1.52.0
 ```
+
+You can find the latest Tailscale stable version number at
+https://pkgs.tailscale.com/stable/#static.

--- a/action.yml
+++ b/action.yml
@@ -79,10 +79,11 @@ runs:
           else
             URL="https://pkgs.tailscale.com/unstable/tailscale_${VERSION}_${TS_ARCH}.tgz"
           fi
+          echo "Downloading $URL"
+          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.tgz --max-time 300 --fail
           if ! [[ "$SHA256SUM" ]] ; then
-            SHA256SUM="$(curl -H user-agent:tailscale-github-action -L "${URL}.sha256")"
+            SHA256SUM="$(curl -H user-agent:tailscale-github-action -L "${URL}.sha256" --fail)"
           fi
-          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.tgz --max-time 300
           echo "Expected sha256: $SHA256SUM"
           echo "Actual sha256: $(sha256sum tailscale.tgz)"
           echo "$SHA256SUM  tailscale.tgz" | sha256sum -c


### PR DESCRIPTION
If package or SHA download from pkgs.tailscale.com fails with a non-200 repsonse code, make the whole action fail. This catches things like incorrect versions.

Example failure: https://github.com/tailscale/github-action/actions/runs/8808942236/job/24178922442

Updates #118