### PR TITLE
Always pull latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ with any of the Users on the tailnet, it has to Tag its nodes.
 Nodes created by this Action are [marked as Ephemeral](https://tailscale.com/s/ephemeral-nodes) to
 be automatically removed by the coordination server a short time after they
 finish their run. The nodes are also [marked Preapproved](https://tailscale.com/kb/1085/auth-keys/)
-on Tailnets which use [Device Approval](https://tailscale.com/kb/1099/device-approval/)
+on tailnets which use [Device Approval](https://tailscale.com/kb/1099/device-approval/)
 
 ## Defining Tailscale version
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ with any of the Users on the tailnet, it has to Tag its nodes.
 Nodes created by this Action are [marked as Ephemeral](https://tailscale.com/s/ephemeral-nodes) to
 be automatically removed by the coordination server a short time after they
 finish their run. The nodes are also [marked Preapproved](https://tailscale.com/kb/1085/auth-keys/)
-on tailnets which use [Device Approval](https://tailscale.com/kb/1099/device-approval/)
+on Tailnets which use [Device Approval](https://tailscale.com/kb/1099/device-approval/)
 
 ## Defining Tailscale version
 
@@ -39,6 +39,18 @@ Which Tailscale version to use can be set like this:
       oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
       tags: tag:ci
       version: 1.52.0
+```
+
+If you'd like to specify the latest version, simply set the version as `latest`
+
+```yaml
+  - name: Tailscale
+    uses: tailscale/github-action@v2
+    with:
+      oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+      oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+      tags: tag:ci
+      version: latest
 ```
 
 You can find the latest Tailscale stable version number at

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   version:
     description: 'Tailscale version to use.'
     required: true
-    default: '1.66.3'
+    default: 'latest'
   sha256sum:
     description: 'Expected SHA256 checksum of the tarball.'
     required: false
@@ -62,6 +62,10 @@ runs:
           VERSION: ${{ inputs.version }}
           SHA256SUM: ${{ inputs.sha256sum }}
         run: |
+          if [ "$VERSION" = "latest" ]; then
+            VERSION=$(curl -s https://pkgs.tailscale.com/stable/ | grep -o 'value="[0-9.]*"' | sed 's/value="//;s/"//' | sort -V | tail -n 1)
+            echo "Latest Tailscale version: $VERSION"
+          fi
           if [ ${{ runner.arch }} = "ARM64" ]; then
             TS_ARCH="arm64"
           elif [ ${{ runner.arch }} = "ARM" ]; then

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
           SHA256SUM: ${{ inputs.sha256sum }}
         run: |
           if [ "$VERSION" = "latest" ]; then
-            VERSION=$(curl -s https://pkgs.tailscale.com/stable/ | grep -o 'value="[0-9.]*"' | sed 's/value="//;s/"//' | sort -V | tail -n 1)
+            VERSION=$(curl -s "https://pkgs.tailscale.com/stable/?mode=json" | jq -r .Version)
             echo "Latest Tailscale version: $VERSION"
           fi
           if [ ${{ runner.arch }} = "ARM64" ]; then

--- a/action.yml
+++ b/action.yml
@@ -62,10 +62,6 @@ runs:
           VERSION: ${{ inputs.version }}
           SHA256SUM: ${{ inputs.sha256sum }}
         run: |
-          if [ "$VERSION" = "latest" ]; then
-            VERSION=$(curl -s https://pkgs.tailscale.com/stable/ | grep -o 'value="[0-9.]*"' | sed 's/value="//;s/"//' | sort -V | tail -n 1)
-            echo "Latest Tailscale version: $VERSION"
-          fi
           if [ ${{ runner.arch }} = "ARM64" ]; then
             TS_ARCH="arm64"
           elif [ ${{ runner.arch }} = "ARM" ]; then

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,10 @@ runs:
           VERSION: ${{ inputs.version }}
           SHA256SUM: ${{ inputs.sha256sum }}
         run: |
+          if [ "$VERSION" = "latest" ]; then
+            VERSION=$(curl -s https://pkgs.tailscale.com/stable/ | grep -o 'value="[0-9.]*"' | sed 's/value="//;s/"//' | sort -V | tail -n 1)
+            echo "Latest Tailscale version: $VERSION"
+          fi
           if [ ${{ runner.arch }} = "ARM64" ]; then
             TS_ARCH="arm64"
           elif [ ${{ runner.arch }} = "ARM" ]; then

--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,9 @@ inputs:
     description: 'Comma separated list of Tags to be applied to nodes. The OAuth client must have permission to apply these tags.'
     required: false
   version:
-    description: 'Tailscale version to use.'
+    description: 'Tailscale version to use. Specify `latest` to use the latest stable version.'
     required: true
-    default: 'latest'
+    default: '1.66.3'
   sha256sum:
     description: 'Expected SHA256 checksum of the tarball.'
     required: false


### PR DESCRIPTION
Allows setting the latest version to `latest` which will grab the latest version of tailscale. The default remains unchanged

Note: this updates the actual action script to find the latest version so we can validate the sha. 

Fixes #28