### PR TITLE
.github/workflows: use default Tailscale version in CI

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -22,7 +22,6 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
-          version: 1.64.0
 
       - name: check for hello.ts.net in netmap
         run:


### PR DESCRIPTION
This makes sure that we test with the default version as specified in action.yml

Updates #cleanup