### PR TITLE
CI: fix the connection check

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -26,7 +26,7 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
 
-      - name: check for hello.ts.net in netmap
+      - name: check for tailscale connection
         shell: bash
         run:
-          tailscale status | grep -q hello
+          tailscale status -json | jq -r .BackendState | grep -q Running


### PR DESCRIPTION
Checking for hello is not the best way to verify that Tailscale is connected, and it recently broke because we stopped giving ephemeral nodes access to hello.

Instead, check for connection by parsing the status output as recommended in our KB article https://tailscale.com/kb/1073/hello