### PR TITLE
.github/workflows: pin GitHub action versions

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Tailscale Action
         uses: ./


### PR DESCRIPTION
Pin versions of GitHub actions that are used in our workflows.

Updates #cleanup