### PR TITLE
Cache tailscale binary file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,7 @@ runs:
         run: |
           echo "::error title=⛔ error hint::OAuth identity empty, Maybe you need to populate it in the Secrets for your workflow, see more in https://docs.github.com/en/actions/security-guides/encrypted-secrets and https://tailscale.com/s/oauth-clients"
           exit 1
+
       - name: Set Resolved Version
         shell: bash
         run: |
@@ -74,11 +75,9 @@ runs:
           fi
           echo "RESOLVED_VERSION=$RESOLVED_VERSION" >> $GITHUB_ENV
           echo "Resolved Tailscale version: $RESOLVED_VERSION"
-      - name: Download Tailscale - Linux
+      - name: Set Tailscale Architecture - Linux
         if: ${{ runner.os == 'Linux' }}
         shell: bash
-        env:
-          SHA256SUM: ${{ inputs.sha256sum }}
         run: |
           if [ ${{ runner.arch }} = "ARM64" ]; then
             TS_ARCH="arm64"
@@ -89,6 +88,35 @@ runs:
           else
             TS_ARCH="amd64"
           fi
+          echo "TS_ARCH=$TS_ARCH" >> $GITHUB_ENV
+
+      - name: Set Tailscale Architecture - Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        run: |
+          if [ ${{ runner.arch }} = "ARM64" ]; then
+            TS_ARCH="arm64"
+          elif [ ${{ runner.arch }} = "X86" ]; then
+            TS_ARCH="x86"
+          else
+            TS_ARCH="amd64"
+          fi
+          echo "TS_ARCH=$TS_ARCH" >> $GITHUB_ENV
+
+      - name: Cache Tailscale Binary - Linux
+        if: ${{ runner.os == 'Linux' }}
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache-tailscale-linux
+        with:
+          path: tailscale.tgz
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}
+
+      - name: Download Tailscale - Linux
+        if: ${{ runner.os == 'Linux' && steps.cache-tailscale-linux.outputs.cache-hit != 'true' }}
+        shell: bash
+        env:
+          SHA256SUM: ${{ inputs.sha256sum }}
+        run: |
           MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
           if [ $((MINOR % 2)) -eq 0 ]; then
             URL="https://pkgs.tailscale.com/stable/tailscale_${RESOLVED_VERSION}_${TS_ARCH}.tgz"
@@ -103,23 +131,29 @@ runs:
           echo "Expected sha256: $SHA256SUM"
           echo "Actual sha256: $(sha256sum tailscale.tgz)"
           echo "$SHA256SUM  tailscale.tgz" | sha256sum -c
+      
+      - name: Install Tailscale - Linux
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
           tar -C /tmp -xzf tailscale.tgz
-          rm tailscale.tgz
           TSPATH=/tmp/tailscale_${RESOLVED_VERSION}_${TS_ARCH}
           sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
-      - name: Download Tailscale - Windows
+
+      - name: Cache Tailscale Binary - Windows
         if: ${{ runner.os == 'Windows' }}
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache-tailscale-windows
+        with:
+          path: tailscale.msi
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}
+
+      - name: Download Tailscale - Windows
+        if: ${{ runner.os == 'Windows' && steps.cache-tailscale-windows.outputs.cache-hit != 'true' }}
         shell: bash
         env:
           SHA256SUM: ${{ inputs.sha256sum }}
         run: |
-          if [ ${{ runner.arch }} = "ARM64" ]; then
-            TS_ARCH="arm64"
-          elif [ ${{ runner.arch }} = "X86" ]; then
-            TS_ARCH="x86"
-          else
-            TS_ARCH="amd64"
-          fi
           MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
           if [ $((MINOR % 2)) -eq 0 ]; then
             URL="https://pkgs.tailscale.com/stable/tailscale-setup-${RESOLVED_VERSION}-${TS_ARCH}.msi"

--- a/action.yml
+++ b/action.yml
@@ -204,7 +204,6 @@ runs:
         run: |
           Start-Process "C:\Windows\System32\msiexec.exe" -Wait -ArgumentList @('/quiet', '/l*v tailscale.log', '/i', 'tailscale.msi')
           Add-Content $env:GITHUB_PATH "C:\Program Files\Tailscale\"
-          Remove-Item tailscale.msi -Force;
       - name: Checkout Tailscale repo - macOS
         id: checkout-tailscale-macos
         if: ${{ runner.os == 'macOS' }}

--- a/action.yml
+++ b/action.yml
@@ -103,19 +103,35 @@ runs:
           fi
           echo "TS_ARCH=$TS_ARCH" >> $GITHUB_ENV
 
+      - name: Set SHA256 - Linux
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
+          if [ $((MINOR % 2)) -eq 0 ]; then
+            URL="https://pkgs.tailscale.com/stable/tailscale_${RESOLVED_VERSION}_${TS_ARCH}.tgz.sha256"
+          else
+            URL="https://pkgs.tailscale.com/unstable/tailscale_${RESOLVED_VERSION}_${TS_ARCH}.tgz.sha256"
+          fi
+          
+          if [[ "${{ inputs.sha256sum }}" ]]; then
+            SHA256SUM="${{ inputs.sha256sum }}"
+          else
+            SHA256SUM="$(curl -H user-agent:tailscale-github-action -L "${URL}" --fail)"
+          fi
+          echo "SHA256SUM=$SHA256SUM" >> $GITHUB_ENV
+          
       - name: Cache Tailscale Binary - Linux
         if: ${{ runner.os == 'Linux' }}
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: cache-tailscale-linux
         with:
           path: tailscale.tgz
-          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}-${{ env.SHA256SUM }}
 
       - name: Download Tailscale - Linux
         if: ${{ runner.os == 'Linux' && steps.cache-tailscale-linux.outputs.cache-hit != 'true' }}
         shell: bash
-        env:
-          SHA256SUM: ${{ inputs.sha256sum }}
         run: |
           MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
           if [ $((MINOR % 2)) -eq 0 ]; then
@@ -125,9 +141,6 @@ runs:
           fi
           echo "Downloading $URL"
           curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.tgz --max-time 300 --fail
-          if ! [[ "$SHA256SUM" ]] ; then
-            SHA256SUM="$(curl -H user-agent:tailscale-github-action -L "${URL}.sha256" --fail)"
-          fi
           echo "Expected sha256: $SHA256SUM"
           echo "Actual sha256: $(sha256sum tailscale.tgz)"
           echo "$SHA256SUM  tailscale.tgz" | sha256sum -c
@@ -140,19 +153,35 @@ runs:
           TSPATH=/tmp/tailscale_${RESOLVED_VERSION}_${TS_ARCH}
           sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
 
+      - name: Set SHA256 - Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: bash
+        run: |
+          MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
+          if [ $((MINOR % 2)) -eq 0 ]; then
+            URL="https://pkgs.tailscale.com/stable/tailscale-setup-${RESOLVED_VERSION}-${TS_ARCH}.msi.sha256"
+          else
+            URL="https://pkgs.tailscale.com/unstable/tailscale-setup-${RESOLVED_VERSION}-${TS_ARCH}.msi.sha256"
+          fi
+          
+          if [[ "${{ inputs.sha256sum }}" ]]; then
+            SHA256SUM="${{ inputs.sha256sum }}"
+          else
+            SHA256SUM="$(curl -H user-agent:tailscale-github-action -L "${URL}" --fail)"
+          fi
+          echo "SHA256SUM=$SHA256SUM" >> $GITHUB_ENV
+
       - name: Cache Tailscale Binary - Windows
         if: ${{ runner.os == 'Windows' }}
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: cache-tailscale-windows
         with:
           path: tailscale.msi
-          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}-${{ env.SHA256SUM }}
 
       - name: Download Tailscale - Windows
         if: ${{ runner.os == 'Windows' && steps.cache-tailscale-windows.outputs.cache-hit != 'true' }}
         shell: bash
-        env:
-          SHA256SUM: ${{ inputs.sha256sum }}
         run: |
           MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
           if [ $((MINOR % 2)) -eq 0 ]; then
@@ -162,9 +191,6 @@ runs:
           fi
           echo "Downloading $URL"
           curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.msi --max-time 300 --fail
-          if ! [[ "$SHA256SUM" ]] ; then
-            SHA256SUM="$(curl -H user-agent:tailscale-github-action -L "${URL}.sha256" --fail)"
-          fi
           echo "Expected sha256: $SHA256SUM"
           echo "Actual sha256: $(sha256sum tailscale.msi)"
           echo "$SHA256SUM  tailscale.msi" | sha256sum -c

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: 'Timeout for `tailscale up`'
     required: false
     default: '2m'
+  use-cache:
+    description: 'Whether to cache the Tailscale binaries (Linux/macOS) or installer (Windows)'
+    required: false
+    default: 'false'
 runs:
     using: 'composite'
     steps:
@@ -122,7 +126,7 @@ runs:
           echo "SHA256SUM=$SHA256SUM" >> $GITHUB_ENV
           
       - name: Cache Tailscale Binary - Linux
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ inputs.use-cache == 'true' && runner.os == 'Linux' }}
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: cache-tailscale-linux
         with:
@@ -130,7 +134,7 @@ runs:
           key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}-${{ env.SHA256SUM }}
 
       - name: Download Tailscale - Linux
-        if: ${{ runner.os == 'Linux' && steps.cache-tailscale-linux.outputs.cache-hit != 'true' }}
+        if: ${{ runner.os == 'Linux' && (inputs.use-cache != 'true' || steps.cache-tailscale-linux.outputs.cache-hit != 'true') }}
         shell: bash
         run: |
           MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
@@ -172,7 +176,7 @@ runs:
           echo "SHA256SUM=$SHA256SUM" >> $GITHUB_ENV
 
       - name: Cache Tailscale Binary - Windows
-        if: ${{ runner.os == 'Windows' }}
+        if: ${{ inputs.use-cache == 'true' && runner.os == 'Windows' }}
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: cache-tailscale-windows
         with:
@@ -180,7 +184,7 @@ runs:
           key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}-${{ env.SHA256SUM }}
 
       - name: Download Tailscale - Windows
-        if: ${{ runner.os == 'Windows' && steps.cache-tailscale-windows.outputs.cache-hit != 'true' }}
+        if: ${{ runner.os == 'Windows' && (inputs.use-cache != 'true' || steps.cache-tailscale-windows.outputs.cache-hit != 'true') }}
         shell: bash
         run: |
           MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
@@ -202,14 +206,24 @@ runs:
           Add-Content $env:GITHUB_PATH "C:\Program Files\Tailscale\"
           Remove-Item tailscale.msi -Force;
       - name: Checkout Tailscale repo - macOS
+        id: checkout-tailscale-macos
         if: ${{ runner.os == 'macOS' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: tailscale/tailscale
           path: ${{ github.workspace }}/tailscale
           ref: v${{ env.RESOLVED_VERSION }}
+      - name: Cache Tailscale - macOS
+        if: ${{ inputs.use-cache == 'true' && runner.os == 'macOS' }}
+        id: cache-tailscale-macos
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            /usr/local/bin/tailscale
+            /usr/local/bin/tailscaled
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ runner.arch }}-${{ steps.checkout-tailscale-macos.outputs.commit }}
       - name: Build Tailscale binaries - macOS
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ runner.os == 'macOS' && (inputs.use-cache != 'true' || steps.cache-tailscale-macos.outputs.cache-hit != 'true') }}
         shell: bash
         run: |
           cd tailscale


### PR DESCRIPTION
This PR adds caching for Tailscale binary downloads to improve workflow performance and reduce bandwidth usage.

Motivation

At our company, we've experienced occasional download failures when our GitHub Actions workflows run on slower network nodes. These intermittent failures disrupt our CI/CD pipelines and require manual intervention. By implementing caching, we can significantly reduce these failures and improve the reliability of our workflows.

Changes:
- Added SHA256-based cache keys for Linux and Windows platforms
- Separated checksum retrieval, caching, and download steps for better organization
- Optimized the download process to only fetch files when not available in cache

This change is backward compatible and requires no configuration changes from users.

related issues: #87 #156