### PR TITLE
feat: Add optional caching to skip repeated Tailscale downloads and builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: 'Timeout for `tailscale up`'
     required: false
     default: '2m'
+  use-cache:
+    description: 'Whether to cache the Tailscale binaries (Linux/macOS) or installer (Windows)'
+    required: false
+    default: 'false'
 runs:
     using: 'composite'
     steps:
@@ -74,8 +78,17 @@ runs:
           fi
           echo "RESOLVED_VERSION=$RESOLVED_VERSION" >> $GITHUB_ENV
           echo "Resolved Tailscale version: $RESOLVED_VERSION"
+      - name: Cache Tailscale - Linux
+        if: ${{ inputs.use-cache == 'true' && runner.os == 'Linux' }}
+        id: cache-tailscale-linux
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            /usr/bin/tailscale
+            /usr/bin/tailscaled
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ runner.arch }}
       - name: Download Tailscale - Linux
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ runner.os == 'Linux' && (inputs.use-cache != 'true' || steps.cache-tailscale-linux.outputs.cache-hit != 'true') }}
         shell: bash
         env:
           SHA256SUM: ${{ inputs.sha256sum }}
@@ -107,8 +120,16 @@ runs:
           rm tailscale.tgz
           TSPATH=/tmp/tailscale_${RESOLVED_VERSION}_${TS_ARCH}
           sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
+      - name: Cache Tailscale - Windows
+        if: ${{ inputs.use-cache == 'true' && runner.os == 'Windows' }}
+        id: cache-tailscale-windows
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            tailscale.msi
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ runner.arch }}
       - name: Download Tailscale - Windows
-        if: ${{ runner.os == 'Windows' }}
+        if: ${{ runner.os == 'Windows' && (inputs.use-cache != 'true' || steps.cache-tailscale-windows.outputs.cache-hit != 'true') }}
         shell: bash
         env:
           SHA256SUM: ${{ inputs.sha256sum }}
@@ -141,15 +162,24 @@ runs:
           Start-Process "C:\Windows\System32\msiexec.exe" -Wait -ArgumentList @('/quiet', '/l*v tailscale.log', '/i', 'tailscale.msi')
           Add-Content $env:GITHUB_PATH "C:\Program Files\Tailscale\"
           Remove-Item tailscale.msi -Force;
+      - name: Cache Tailscale - macOS
+        if: ${{ inputs.use-cache == 'true' && runner.os == 'macOS' }}
+        id: cache-tailscale-macos
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            /usr/local/bin/tailscale
+            /usr/local/bin/tailscaled
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ runner.arch }}
       - name: Checkout Tailscale repo - macOS
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ runner.os == 'macOS' && (inputs.use-cache != 'true' || steps.cache-tailscale-macos.outputs.cache-hit != 'true') }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: tailscale/tailscale
           path: ${{ github.workspace }}/tailscale
           ref: v${{ env.RESOLVED_VERSION }}
       - name: Build Tailscale binaries - macOS
-        if: ${{ runner.os == 'macOS' }}
+        if: ${{ runner.os == 'macOS' && (inputs.use-cache != 'true' || steps.cache-tailscale-macos.outputs.cache-hit != 'true') }}
         shell: bash
         run: |
           cd tailscale


### PR DESCRIPTION
This commit introduces a new `use-cache` input to the Tailscale GitHub Action. When set to `true`, the action will attempt to restore/install Tailscale binaries from a GitHub Actions cache, rather than always downloading or rebuilding them. If the cache is a hit, the download/build steps are skipped, reducing network flakes and speeding up workflows. The default `false` preserves the original behavior, ensuring full backward compatibility.

Fixes #87 
Duplicates (kinda) #166 

Will be using this internally to make sure no issues, but prefer to contribute upstream if possible!