### PR TITLE
force curl to use HTTP/1.1 for package downloads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ runs:
             URL="https://pkgs.tailscale.com/unstable/tailscale_${RESOLVED_VERSION}_${TS_ARCH}.tgz"
           fi
           echo "Downloading $URL"
-          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.tgz --max-time 300 --fail
+          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.tgz --http1.1 --max-time 300 --fail
           if ! [[ "$SHA256SUM" ]] ; then
             SHA256SUM="$(curl -H user-agent:tailscale-github-action -L "${URL}.sha256" --fail)"
           fi
@@ -127,7 +127,7 @@ runs:
             URL="https://pkgs.tailscale.com/unstable/tailscale-setup-${RESOLVED_VERSION}-${TS_ARCH}.msi"
           fi
           echo "Downloading $URL"
-          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.msi --max-time 300 --fail
+          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.msi --http1.1 --max-time 300 --fail
           if ! [[ "$SHA256SUM" ]] ; then
             SHA256SUM="$(curl -H user-agent:tailscale-github-action -L "${URL}.sha256" --fail)"
           fi


### PR DESCRIPTION
Intermittent failures to fetch the tailscale package seem to be an HTTP/2 issue.   HTTP/2 isn't doing anything better than HTTP/1.1 for fetching a single file so why not try downgrading the protocol?

the error:
`curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)`

the reported issue:
https://github.com/tailscale/github-action/issues/158

reference: 
https://stackoverflow.com/questions/56413290/getting-curl-92-http-2-stream-1-was-not-closed-cleanly-internal-error-err