### PR TITLE
action.yml: properly remove temporary files after downloading

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        cache: ['false', 'true']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
@@ -25,8 +26,19 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
+          use-cache: ${{ matrix.cache }}
 
       - name: check for tailscale connection
         shell: bash
         run:
           tailscale status -json | jq -r .BackendState | grep -q Running
+
+      - name: ensure no dirty files from Tailscale Action remain
+        shell: bash
+        run: |
+          extra_files=$(git ls-files . --exclude-standard --others)
+          if [ ! -z "$extra_files" ]; then
+            echo "::error::Unexpected extra files: $extra_files"
+            exit 1
+          fi
+

--- a/action.yml
+++ b/action.yml
@@ -125,16 +125,16 @@ runs:
           fi
           echo "SHA256SUM=$SHA256SUM" >> $GITHUB_ENV
           
-      - name: Cache Tailscale Binary - Linux
+      - name: Restore Tailscale Binary - Linux
         if: ${{ inputs.use-cache == 'true' && runner.os == 'Linux' }}
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        id: cache-tailscale-linux
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: restore-cache-tailscale-linux
         with:
           path: tailscale.tgz
           key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}-${{ env.SHA256SUM }}
 
       - name: Download Tailscale - Linux
-        if: ${{ runner.os == 'Linux' && (inputs.use-cache != 'true' || steps.cache-tailscale-linux.outputs.cache-hit != 'true') }}
+        if: ${{ runner.os == 'Linux' && (inputs.use-cache != 'true' || steps.restore-cache-tailscale-linux.outputs.cache-hit != 'true') }}
         shell: bash
         run: |
           MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
@@ -148,12 +148,21 @@ runs:
           echo "Expected sha256: $SHA256SUM"
           echo "Actual sha256: $(sha256sum tailscale.tgz)"
           echo "$SHA256SUM  tailscale.tgz" | sha256sum -c
+
+      - name: Save Tailscale Binary - Linux
+        if: ${{ inputs.use-cache == 'true' && steps.restore-cache-tailscale-linux.outputs.cache-hit != 'true' && runner.os == 'Linux' }}
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: save-cache-tailscale-linux
+        with:
+          path: tailscale.tgz
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}-${{ env.SHA256SUM }}
       
       - name: Install Tailscale - Linux
         if: ${{ runner.os == 'Linux' }}
         shell: bash
         run: |
           tar -C /tmp -xzf tailscale.tgz
+          rm tailscale.tgz
           TSPATH=/tmp/tailscale_${RESOLVED_VERSION}_${TS_ARCH}
           sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
 
@@ -175,16 +184,16 @@ runs:
           fi
           echo "SHA256SUM=$SHA256SUM" >> $GITHUB_ENV
 
-      - name: Cache Tailscale Binary - Windows
+      - name: Restore Tailscale Binary - Windows
         if: ${{ inputs.use-cache == 'true' && runner.os == 'Windows' }}
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        id: cache-tailscale-windows
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: restore-cache-tailscale-windows
         with:
           path: tailscale.msi
           key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}-${{ env.SHA256SUM }}
 
       - name: Download Tailscale - Windows
-        if: ${{ runner.os == 'Windows' && (inputs.use-cache != 'true' || steps.cache-tailscale-windows.outputs.cache-hit != 'true') }}
+        if: ${{ runner.os == 'Windows' && (inputs.use-cache != 'true' || steps.restore-cache-tailscale-windows.outputs.cache-hit != 'true') }}
         shell: bash
         run: |
           MINOR=$(echo "$RESOLVED_VERSION" | awk -F '.' {'print $2'})
@@ -198,12 +207,22 @@ runs:
           echo "Expected sha256: $SHA256SUM"
           echo "Actual sha256: $(sha256sum tailscale.msi)"
           echo "$SHA256SUM  tailscale.msi" | sha256sum -c
+
+      - name: Save Tailscale Binary - Windows
+        if: ${{ inputs.use-cache == 'true' && steps.restore-cache-tailscale-windows.outputs.cache-hit != 'true' && runner.os == 'Windows' }}
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: save-cache-tailscale-windows
+        with:
+          path: tailscale.msi
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ env.TS_ARCH }}-${{ env.SHA256SUM }}
+
       - name: Install Tailscale - Windows
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: |
-          Start-Process "C:\Windows\System32\msiexec.exe" -Wait -ArgumentList @('/quiet', '/l*v tailscale.log', '/i', 'tailscale.msi')
+          Start-Process "C:\Windows\System32\msiexec.exe" -Wait -ArgumentList @('/quiet', '/l*v ${{ runner.temp }}/tailscale.log', '/i', 'tailscale.msi')
           Add-Content $env:GITHUB_PATH "C:\Program Files\Tailscale\"
+          Remove-Item tailscale.msi -Force;
       - name: Checkout Tailscale repo - macOS
         id: checkout-tailscale-macos
         if: ${{ runner.os == 'macOS' }}
@@ -212,17 +231,17 @@ runs:
           repository: tailscale/tailscale
           path: ${{ github.workspace }}/tailscale
           ref: v${{ env.RESOLVED_VERSION }}
-      - name: Cache Tailscale - macOS
+      - name: Restore Tailscale - macOS
         if: ${{ inputs.use-cache == 'true' && runner.os == 'macOS' }}
-        id: cache-tailscale-macos
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: restore-cache-tailscale-macos
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             /usr/local/bin/tailscale
             /usr/local/bin/tailscaled
           key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ runner.arch }}-${{ steps.checkout-tailscale-macos.outputs.commit }}
       - name: Build Tailscale binaries - macOS
-        if: ${{ runner.os == 'macOS' && (inputs.use-cache != 'true' || steps.cache-tailscale-macos.outputs.cache-hit != 'true') }}
+        if: ${{ runner.os == 'macOS' && (inputs.use-cache != 'true' || steps.restore-cache-tailscale-macos.outputs.cache-hit != 'true') }}
         shell: bash
         run: |
           cd tailscale
@@ -230,6 +249,20 @@ runs:
           ./build_dist.sh ./cmd/tailscale
           ./build_dist.sh ./cmd/tailscaled
           sudo mv tailscale tailscaled /usr/local/bin
+      - name: Remove tailscale checkout - macOS
+        if: ${{ runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          rm -Rf ${{ github.workspace }}/tailscale
+      - name: Save Tailscale - macOS
+        if: ${{ inputs.use-cache == 'true' && runner.os == 'macOS' }}
+        id: save-cache-tailscale-macos
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            /usr/local/bin/tailscale
+            /usr/local/bin/tailscaled
+          key: ${{ runner.os }}-tailscale-${{ env.RESOLVED_VERSION }}-${{ runner.arch }}-${{ steps.checkout-tailscale-macos.outputs.commit }}
       - name: Install timeout - macOS
         if: ${{ runner.os == 'macOS' }}
         shell: bash


### PR DESCRIPTION
Remove `.tgz` and `.msi` files after they have been downloaded. This was the behaviour of the action previous to `v3.2.0`, but our logic for caching removed the deletion of these files.

Can look at downloading these to temp folders to avoid the more complex logic here as a follow up, but this should unblock / fix the immediate regression.

Updates: https://github.com/tailscale/github-action/issues/170