### PR TITLE
{.github/workflows,action.yml}: run windows in unattended mode

### DIFF
--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, windows-11-arm]
         cache: ['false', 'true']
     runs-on: ${{ matrix.os }}
     steps:

--- a/action.yml
+++ b/action.yml
@@ -313,9 +313,12 @@ runs:
           if [ "${{ runner.os }}" != "Windows" ]; then
             MAYBE_SUDO="sudo -E"
           fi
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            PLATFORM_SPECIFIC_ARGS="--unattended"
+          fi
           for ((i=1;i<=$RETRY;i++)); do
             echo "Attempt $i to bring up Tailscale..."
-            timeout --verbose --kill-after=1s ${TIMEOUT} ${MAYBE_SUDO} tailscale up ${TAGS_ARG} --authkey=${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${ADDITIONAL_ARGS} && break
+            timeout --verbose --kill-after=1s ${TIMEOUT} ${MAYBE_SUDO} tailscale up ${TAGS_ARG} --authkey=${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME} --accept-routes ${PLATFORM_SPECIFIC_ARGS} ${ADDITIONAL_ARGS} && break
             echo "Tailscale up failed. Retrying in $((i * 5)) seconds..."
             sleep $((i * 5))
           done


### PR DESCRIPTION
Add the `--unattended` flag when running the action on windows-based machines. This allows the action to properly connect on windows machines that do not have full GUI support under the hood (e.g., for the current batch of `windows-11-arm` runners).

Fixes https://github.com/tailscale/github-action/issues/180