### PR TITLE
README.md: update required scopes for oauth clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Subsequent steps in the Action can then access nodes in your Tailnet.
 oauth-client-id and oauth-secret are an [OAuth client](https://tailscale.com/s/oauth-clients/)
 for the tailnet to be accessed. We recommend storing these as
 [GitHub Encrypted Secrets.](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
-OAuth clients used for this purpose must have the
-[`auth_keys` scope.](https://tailscale.com/kb/1215/oauth-clients#scopes)
+OAuth clients used for this purpose must have the following
+[scopes](https://tailscale.com/kb/1215/oauth-clients#scopes):
+`all:read`, `auth_keys`, and `devices:core`.
 
 tags is a comma-separated list of one or more [ACL Tags](https://tailscale.com/kb/1068/acl-tags/)
 for the node. At least one tag is required: an OAuth client is not associated


### PR DESCRIPTION
The guidance provided for the proper scopes for oauth clients is incomplete. It only includes the `auth_keys` [scope](https://tailscale.com/kb/1215/oauth-clients#scopes), but any oauth client using this github action should also include `all:read` and `devices:core`. This follows the suggestion provided in https://github.com/tailscale/github-action/issues/100#issuecomment-2726800559. 

I have attempted to follow the contributing guidelines found in [commit-messages.md](https://github.com/tailscale/tailscale/blob/main/docs/commit-messages.md).

Note: The documentation on [tailscale's website](https://tailscale.com/kb/1276/tailscale-github-action?q=action#how-it-works) will need to be updated as well.