### PR TITLE
Support `unstable` version alias

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: 'Comma separated list of Tags to be applied to nodes. The OAuth client must have permission to apply these tags.'
     required: false
   version:
-    description: 'Tailscale version to use. Specify `latest` to use the latest stable version, and `unstable` to use the latest unstable version.'
+    description: 'Tailscale version to use. Specify `latest` to use the latest stable version, and `unstable` to use the latest development version.'
     required: true
     default: '1.82.0'
   sha256sum:


### PR DESCRIPTION
Support `unstable` version alias.
Like the `latest` alias, it is easier to use an alias rather than specifying the `unstable` version directly.