### PR TITLE
Wait for tailscale to be able to resolve domains

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -322,3 +322,8 @@ runs:
             echo "Tailscale up failed. Retrying in $((i * 5)) seconds..."
             sleep $((i * 5))
           done
+          for ((i=1;i<=$RETRY;i++)); do
+            timeout --verbose --kill-after=1s ${TIMEOUT} ${MAYBE_SUDO} bash -c 'while tailscale dns query google.com. a | grep "failed to query DNS"; do sleep 1; done' && break
+            echo "Tailscale failed to resolve google.com.. Retrying in $((i * 5)) seconds..."
+            sleep $((i * 5))
+          done


### PR DESCRIPTION
Ensures DNS resolving is working before we continue. We do that because sometimes, mostly when the US wake up, GitHub Action network becomes overloaded and Tailscale tunnels to our DNS resolvers take some time to become available. This results in the following step being unable to resolve and fails.

Fixes https://github.com/tailscale/github-action/issues/107.