### PR TITLE
Added argument to test targets connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This GitHub Action connects to your [Tailscale network](https://tailscale.com)
 by adding a step to your workflow.
 
 ```yaml
-  - name: Tailscale
-    uses: tailscale/github-action@v3
-    with:
-      oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-      oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-      tags: tag:ci
+- name: Tailscale
+  uses: tailscale/github-action@v3
+  with:
+    oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+    oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+    tags: tag:ci
 ```
 
 Subsequent steps in the Action can then access nodes in your Tailnet.
@@ -29,6 +29,28 @@ be automatically removed by the coordination server a short time after they
 finish their run. The nodes are also [marked Preapproved](https://tailscale.com/kb/1085/auth-keys/)
 on tailnets which use [Device Approval](https://tailscale.com/kb/1099/device-approval/)
 
+## Eventual consistency
+
+Propagating information about new peers - such as the node created by this action - across your tailnet
+is an eventually consistent process, and brief delays are expected. Until the GitHub workflow node 
+becomes visible, other peers will not accept connections. It is best to verify connectivity to the 
+intended nodes before executing steps that rely on them.
+
+You can do this by adding a list of targets to the action configuration:
+
+```yaml
+- name: Tailscale
+  uses: tailscale/github-action@v3
+  with:
+    targets: 100.x.y.z,my-machine.my-tailnet.ts.net
+```
+
+or with the [tailscale ping](https://tailscale.com/kb/1080/cli#ping) command if you do not know the targets at the time of installing Tailscale in the workflow:
+
+```bash
+tailscale ping my-target.my-tailnet.ts.net
+```
+
 ## Tailnet Lock
 
 If you are using this Action in a [Tailnet
@@ -42,11 +64,11 @@ Lock](https://tailscale.com/kb/1226/tailnet-lock) enabled network, you need to:
   client to store the Tailnet Key Authority data in.
 
 ```yaml
-  - name: Tailscale
-    uses: tailscale/github-action@v3
-    with:
-      authkey: tskey-auth-...
-      statedir: /tmp/tailscale-state/
+- name: Tailscale
+  uses: tailscale/github-action@v3
+  with:
+    authkey: tskey-auth-...
+    statedir: /tmp/tailscale-state/
 ```
 
 ## Defining Tailscale version
@@ -54,25 +76,25 @@ Lock](https://tailscale.com/kb/1226/tailnet-lock) enabled network, you need to:
 Which Tailscale version to use can be set like this:
 
 ```yaml
-  - name: Tailscale
-    uses: tailscale/github-action@v3
-    with:
-      oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-      oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-      tags: tag:ci
-      version: 1.52.0
+- name: Tailscale
+  uses: tailscale/github-action@v3
+  with:
+    oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+    oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+    tags: tag:ci
+    version: 1.52.0
 ```
 
 If you'd like to specify the latest version, simply set the version as `latest`
 
 ```yaml
-  - name: Tailscale
-    uses: tailscale/github-action@v3
-    with:
-      oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-      oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-      tags: tag:ci
-      version: latest
+- name: Tailscale
+  uses: tailscale/github-action@v3
+  with:
+    oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+    oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+    tags: tag:ci
+    version: latest
 ```
 
 You can find the latest Tailscale stable version number at
@@ -86,10 +108,10 @@ Caching can reduce download times and download failures on runners with slower n
 You can opt in to caching Tailscale binaries by passing `'true'` to the `use-cache` input:
 
 ```yaml
-  - name: Tailscale
-    uses: tailscale/github-action@v3
-    with:
-      oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-      oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-      use-cache: 'true'
+- name: Tailscale
+  uses: tailscale/github-action@v3
+  with:
+    oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+    oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+    use-cache: 'true'
 ```

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
     description: 'Whether to cache the Tailscale binaries (Linux/macOS) or installer (Windows)'
     required: false
     default: 'false'
+  targets:
+    description: 'Comma separated list of targets (Tailscale IP addresses or machine names if MagicDNS is enabled on the tailnet) to `tailscale ping` for connectivity verification after `tailscale up` completes'
+    required: false
+    default: ''
 runs:
     using: 'composite'
     steps:
@@ -150,7 +154,7 @@ runs:
             URL="https://pkgs.tailscale.com/unstable/tailscale_${RESOLVED_VERSION}_${TS_ARCH}.tgz"
           fi
           echo "Downloading $URL"
-          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.tgz --max-time 300 --fail
+          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.tgz --max-time 300 --retry 3 --retry-all-errors --fail
           echo "Expected sha256: $SHA256SUM"
           echo "Actual sha256: $(sha256sum tailscale.tgz)"
           echo "$SHA256SUM  tailscale.tgz" | sha256sum -c
@@ -209,7 +213,7 @@ runs:
             URL="https://pkgs.tailscale.com/unstable/tailscale-setup-${RESOLVED_VERSION}-${TS_ARCH}.msi"
           fi
           echo "Downloading $URL"
-          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.msi --max-time 300 --fail
+          curl -H user-agent:tailscale-github-action -L "$URL" -o tailscale.msi --max-time 300 --retry 3 --retry-all-errors --fail
           echo "Expected sha256: $SHA256SUM"
           echo "Actual sha256: $(sha256sum tailscale.msi)"
           echo "$SHA256SUM  tailscale.msi" | sha256sum -c
@@ -353,3 +357,38 @@ runs:
             echo "Tailscale up failed. Retrying in $((i * 5)) seconds..."
             sleep $((i * 5))
           done
+      - name: Verify Target Connectivity
+        if: ${{ inputs.targets != '' }}
+        shell: bash
+        env:
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          IFS=',' read -ra TARGET_ARRAY <<< "$TARGETS"
+
+          if [ "${{ runner.os }}" != "Windows" ]; then
+            MAYBE_SUDO="sudo -E"
+          fi
+
+          failed_targets=()
+          for target in "${TARGET_ARRAY[@]}"; do
+            target=$(echo "$target" | xargs)  # trim whitespace
+            if [ -n "$target" ]; then
+              output=$(${MAYBE_SUDO} tailscale ping --c=36 $target 2>&1)
+              exit_code=$?
+
+              if [ $exit_code -eq 0 ]; then
+                echo "Successfully reached $target"
+              elif echo "$output" | grep -q "direct connection not established"; then
+                echo "::warning title=Target Connectivity Warning::Failed to establish direct connection to $target, but connection may still work via DERP"
+              else
+                # Regular failure case
+                echo "Failed to reach $target"
+                failed_targets+=("$target")
+              fi
+            fi
+          done
+
+          if [ ${#failed_targets[@]} -gt 0 ]; then
+            echo "::error title=Target Connectivity Failed::Failed to reach the following targets: ${failed_targets[*]}"
+            exit 1
+          fi

--- a/action.yml
+++ b/action.yml
@@ -379,7 +379,7 @@ runs:
               if [ $exit_code -eq 0 ]; then
                 echo "Successfully reached $target"
               elif echo "$output" | grep -q "direct connection not established"; then
-                echo "::warning title=Target Connectivity Warning::Failed to establish direct connection to $target, but connection may still work via DERP"
+                echo "::warning title=Target Connectivity Warning::Failed to establish direct connection to $target but was able to connect via DERP"
               else
                 # Regular failure case
                 echo "Failed to reach $target"


### PR DESCRIPTION
# Problem

Every change to a Tailscale network causes the netmap - a map of which devices [can connect or know each other](https://tailscale.com/kb/1087/device-visibility) - to be recalculated and distributed to all nodes on the tailnet. When a node on the tailnet tries to connect to a peer, both devices must be allowed to connect according to their netmap. Computing and distributing updated netmap is an eventually consistent process, which means that when a node joins a tailnet there is a small delay before it can connect to the desired targets. If nodeA knows nodeB and tries to connect, but nodeB doesn't know nodeA yet, nodeA will experience what appears to it like a generic network error.

We have good reasons to believe this delay and generic error response is the cause of various issues and PRs reporting instability of the GitHub action. Under normal circumstances, the propagation delay is around ~3 seconds, which is short enough for it to complete before the workflow connects to targets in subsequent steps. However we observed propagation spikes of up to ~33 seconds during periods of particularly high or bursty traffic. The delay could be even more significant for particularly large or dynamic tailnets. The variability of the delay and its relation to overall system pressure explains why the failures are sporadic and concentrated around the same periods.

We also observed rare but consistent flakiness when trying to download the Tailscale client:
`curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)`

Issues and PRs that are possibly related:
* #191 
* #159
* #158 
* #145
* #130 
* #129
* #107 
* #51 
* #193 
* #168 

# Solution

When dealing with eventually consistent systems, the simplest solution is to check before acting. We added an optional `targets` input argument so the Tailscale GitHub Action can absorb the delay by verifying for up to 3 minutes if the targets are reachable before continuing.

If this solution is not acceptable due to the potential execution delay or because the targets are not known at the time the Tailscale action is used, we recommend using `tailscale ping` or other methods to verify connectivity and buffer for the variable propagation delay.

A retry was also added to the curl command that downloads the Tailscale client to mitigate the premature stream closure problem.

# Methodology

We created a monitoring rig to measure the success rate from a consuming workflow's perspective. The test workflow uses the Tailscale GitHub Action to connect to a tailnet and perform a series of commands that were reported as flaky by the various GitHub issues.

Without the changes from this PR, the success rate was around 97%, whereas when using the targets input argument the success rate is now well above 99%.

Note that a number of issues mention that connections via DNS would fail while connection via direct IP was more reliable, but from our tests using the Tailscale IP or the MagicDNS machine name did not make a difference.

Sample result:
```
📊 Tailscale Subdomain
----------------------------------------
   Total runs: 816
   Successful: 812
   Success rate: 99.5%
   Duration p50: 3450ms
   Duration p90: 310193ms
   Duration p95: 319526ms
   Duration p99: 323769ms
   Min duration: 3146ms
   Max duration: 330009ms
```
The 4 failures were due to connectivity only being achieved through a [DERP server](https://tailscale.com/kb/1232/derp-servers) which for the sake of monitoring we consider as unsuccessful.  

# Misc

I've also fixed the README indentation which would supersede the #150 