### PR TITLE
action: auto-sanitize default or error on invalid user-defined hostname

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
     required: false
     default: ''
   hostname:
-    description: 'Fixed hostname to use.'
+    description: 'Fixed hostname to use. Must be a valid DNS label (alphanumeric and dashes only, 1-63 characters, cannot start or end with a dash). If not provided, a hostname will be generated based on the runner name.'
     required: false
     default: ''
   statedir:
@@ -301,13 +301,42 @@ runs:
           TIMEOUT: ${{ inputs.timeout }}
           RETRY: ${{ inputs.retry }}
         run: |
+          sanitize_hostname() {
+            local hostname="$1"
+            hostname=$(echo "$hostname" | sed 's/[^a-zA-Z0-9-]/-/g') # Replace invalid characters with dashes
+            hostname=$(echo "$hostname" | cut -c1-63) # Truncate to 63 characters maximum
+            hostname=$(echo "$hostname" | sed 's/^-*//;s/-*$//') # Remove leading/trailing dashes
+            echo "$hostname"
+          }
+
+          is_valid_dns_label() {
+            local hostname="$1"
+            if [ ${#hostname} -eq 0 ] || [ ${#hostname} -gt 63 ]; then # Check length (1-63 characters)
+              return 1
+            fi
+            if ! echo "$hostname" | grep -qE '^[a-zA-Z0-9-]+$'; then # Check for valid characters (alphanumeric and dashes only)
+              return 1
+            fi
+            if echo "$hostname" | grep -qE '^-|-$'; then # Check that it doesn't start or end with dash
+              return 1
+            fi
+            return 0
+          }
+
           if [ -z "${HOSTNAME}" ]; then
             if [ "${{ runner.os }}" == "Windows" ]; then
               HOSTNAME="github-$COMPUTERNAME"
-            else 
+            else
               HOSTNAME="github-$(hostname)"
             fi
+            HOSTNAME=$(sanitize_hostname "$HOSTNAME")
+          else
+            if ! is_valid_dns_label "$HOSTNAME"; then
+              echo "::error::HOSTNAME '$HOSTNAME' is not a valid DNS label. It should contain only alphanumeric characters and dashes, be 1-63 characters long, and not start or end with a dash."
+              exit 1
+            fi
           fi
+
           if [ -n "${{ inputs['oauth-secret'] }}" ]; then
             TAILSCALE_AUTHKEY="${{ inputs['oauth-secret'] }}?preauthorized=true&ephemeral=true"
             TAGS_ARG="--advertise-tags=${{ inputs.tags }}"


### PR DESCRIPTION
Fixes #192

The issue is not affecting all runners. I was only able to reproduce the issue on MacOS runners.

This PR addresses 2 different scenario wrt the hostname the GH workflows use when joining a tailnet:
* The default hostname generated internally could be - or become due to a GitHub internal update - an invalid DNS label, causing previously valid workflow definitions to fail out of nowhere
* The hostname provided via the input arguments could be invalid but only cause a failure much later during the workflow, sometimes with non-obvious error messages

To address the 1st point we proactively sanitize internally generated hostnames to make them valid DNS labels. Example of a hostname that was proactively sanitized on a MacOS runner:

<img width="1219" height="290" alt="Screenshot 2025-09-23 at 3 09 21 PM" src="https://github.com/user-attachments/assets/dd45adde-5eb1-430c-9d04-01d3661ee539" />

To address the 2nd point, we validate the hostname input is a valid DNS label and fail early with a clear error message if not:

<img width="1746" height="689" alt="Screenshot 2025-09-23 at 3 07 32 PM" src="https://github.com/user-attachments/assets/61a6a0ab-9466-439d-a2f7-e2e8b8731e8a" />

