### PR TITLE
.github: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Add basic dependabot config to check for actions / npm updates daily. This mirrors the config we currently have in the terraform provider repo but with go swapped for npm.

Fixes https://github.com/tailscale/github-action/issues/207