### PR TITLE
.gitattributes: mark dist as a generated folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** linguist-generated=true


### PR DESCRIPTION
Mark dist as a generated folder so that files within it are collapsed by default in code review.

Updates #cleanup