### PR TITLE
src: check against platform specific versions for latest and unstable

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41306,7 +41306,17 @@ async function resolveVersion(version, runnerOS) {
             pkg,
         ]);
         const response = JSON.parse(stdout);
-        return response.Version;
+        switch (runnerOS) {
+            case runnerLinux:
+                return response.TarballsVersion;
+            case runnerMacOS:
+                // Use latest tag on macOS since we are building from source
+                return response.Version;
+            case runnerWindows:
+                return response.MSIsVersion;
+            default:
+                return response.Version;
+        }
     }
     return version;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,7 +262,17 @@ async function resolveVersion(
       pkg,
     ]);
     const response = JSON.parse(stdout);
-    return response.Version;
+    switch (runnerOS) {
+      case runnerLinux:
+        return response.TarballsVersion;
+      case runnerMacOS:
+        // Use latest tag on macOS since we are building from source
+        return response.Version;
+      case runnerWindows:
+        return response.MSIsVersion;
+      default:
+        return response.Version;
+    }
   }
 
   return version;


### PR DESCRIPTION
Check against platform and package specific version numbers returned from pkgs.tailscale.com instead of defaulting to "Version" as this can be incorrect for certain platforms when a release has only been built for a subset of platforms.

For example. 1.90.2 is available for linux at the time of writing so "Version" is 1.90.2, but only 1.90.1 is available for windows which causes an error when using latest as the version specifier on windows machines.

Fixes https://github.com/tailscale/github-action/issues/219