### PR TITLE
fix: Windows MSI download on self-hosted runners

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52873,20 +52873,35 @@ async function installTailscaleWindows(config, toolPath, fromCache = false) {
         }
         // Download MSI
         const downloadUrl = `${baseUrl}/tailscale-setup-${config.resolvedVersion}-${config.arch}.msi`;
-        core.info(`Downloading ${downloadUrl}`);
-        const downloadedMsiPath = await tc.downloadTool(downloadUrl, msiPath);
-        // Verify checksum
-        const actualSha = await calculateFileSha256(downloadedMsiPath);
         const expectedSha = config.sha256Sum.trim().toLowerCase();
-        core.info(`Expected sha256: ${expectedSha}`);
-        core.info(`Actual sha256: ${actualSha}`);
-        if (actualSha !== expectedSha) {
-            throw new Error("SHA256 checksum mismatch");
+        // Check if MSI already exists with correct checksum (for self-hosted runners)
+        let needsDownload = true;
+        if (fs.existsSync(msiPath)) {
+            const existingSha = await calculateFileSha256(msiPath);
+            if (existingSha === expectedSha) {
+                core.info(`Using existing MSI at ${msiPath} (checksum verified)`);
+                needsDownload = false;
+            }
+            else {
+                core.info(`Existing MSI checksum mismatch, re-downloading`);
+                fs.unlinkSync(msiPath);
+            }
         }
-        // Keep the MSI file in toolPath for caching (don't delete it)
-        // The downloadedMsiPath is in temp, but we want to keep it in toolPath
-        if (downloadedMsiPath !== msiPath) {
-            fs.copyFileSync(downloadedMsiPath, msiPath);
+        if (needsDownload) {
+            core.info(`Downloading ${downloadUrl}`);
+            const downloadedMsiPath = await tc.downloadTool(downloadUrl, msiPath);
+            // Verify checksum
+            const actualSha = await calculateFileSha256(downloadedMsiPath);
+            core.info(`Expected sha256: ${expectedSha}`);
+            core.info(`Actual sha256: ${actualSha}`);
+            if (actualSha !== expectedSha) {
+                throw new Error("SHA256 checksum mismatch");
+            }
+            // Keep the MSI file in toolPath for caching (don't delete it)
+            // The downloadedMsiPath is in temp, but we want to keep it in toolPath
+            if (downloadedMsiPath !== msiPath) {
+                fs.copyFileSync(downloadedMsiPath, msiPath);
+            }
         }
     }
     // Install MSI (same for both fresh and cached)


### PR DESCRIPTION
On self-hosted runners, the tool cache directory persists between runs. When GitHub's cloud cache doesn't have an entry (first run, evicted, etc.), but the local MSI file exists from a previous run, tc.downloadTool() fails with "Destination file path already exists".

This fix checks if the existing MSI has a valid checksum before downloading:
- If valid: reuse it (skip download)
- If invalid: delete and re-download