### PR TITLE
src: set GOWORK to "off" for macOS builds

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52652,6 +52652,7 @@ async function installTailscaleMacOS(config, toolPath) {
             env: {
                 ...process.env,
                 TS_USE_TOOLCHAIN: "1",
+                GOWORK: "off",
             },
             logMode: config.logMode,
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -696,6 +696,7 @@ async function installTailscaleMacOS(
         env: {
           ...process.env,
           TS_USE_TOOLCHAIN: "1",
+          GOWORK: "off",
         },
         logMode: config.logMode,
       },


### PR DESCRIPTION
Explicitly set GOWORK to "off" when building macOS from source to ensure we do not pick up go.work files from host repositories where the action is being run.

Updates https://github.com/tailscale/github-action/issues/287